### PR TITLE
Add the ability to specify "out_channel" option for Bidirectional mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ THIS IS ONLY FOR ADVANCED USERS THAT ARE COMFORTABLE EDITING CONFIG FILES
 If you enable the "bidirectional" mode while setting up SetCurrentScene or SetPreviewScene the script will try to open the input device as an output device and listen for Preview or Program scene change events. It will then send out a note_on or control_change event on midi channel 0 to the same note or control channel that is setup for the specific scene.
 
 This default approach might not work for some devices like the X-Touch Mini that have different notes/cc values for the same button depending if the data is coming in or going out. In this case you have to add a value named "out_msgNoC" to the config.json file for the button you want to light up with the right note/cc number.
+To change the default channel you need to add a value named "out_channel" to config.json file.
 
 If the midi out port for your device has a differnt name then the input port this will also not work without modifying the config.json file. For that first use the device configuration as mentioned above to add another device (could be one with a completly differnt name, this only saves you the work of manually adding the whole device which you could also do). Then add a value called "out_deviceID" to the button mapping entry with the value set to the id of the output device you just created. Also make sure that the output device name is the right one.
 

--- a/main.py
+++ b/main.py
@@ -303,14 +303,15 @@ class MidiHandler:
             if j["request-type"] != event_type:
                 continue
             msgNoC = result.get("out_msgNoC", result["msgNoC"])
+            channel = result.get("out_channel", 0)
             portobject = self.getPortObject(result)
             if portobject and portobject._port_out:
                 if result["msg_type"] == "control_change":
                     value = 127 if j["scene-name"] == scene_name else 0
-                    portobject._port_out.send(mido.Message(type="control_change", channel=0, control=msgNoC, value=value))
+                    portobject._port_out.send(mido.Message(type="control_change", channel=channel, control=msgNoC, value=value))
                 elif result["msg_type"] == "note_on":
                     velocity = 1 if j["scene-name"] == scene_name else 0
-                    portobject._port_out.send(mido.Message(type="note_on", channel=0, note=msgNoC, velocity=velocity))
+                    portobject._port_out.send(mido.Message(type="note_on", channel=channel, note=msgNoC, velocity=velocity))
 
     def handle_obs_error(self, ws, error=None):
         # Protection against potential inconsistencies in `inspect.ismethod`
@@ -385,12 +386,13 @@ class MidiHandler:
         if result:
             for row in result:
                 msgNoC = row.get("out_msgNoC", row["msgNoC"])
+                channel = row.get("out_channel", 0)
                 portobject = self.getPortObject(row)
                 if portobject and portobject._port_out:
                     if row["msg_type"] == "control_change":
-                        portobject._port_out.send(mido.Message(type="control_change", channel=0, control=msgNoC, value=0))
+                        portobject._port_out.send(mido.Message(type="control_change", channel=channel, control=msgNoC, value=0))
                     elif row["msg_type"] == "note_on":
-                        portobject._port_out.send(mido.Message(type="note_on", channel=0, note=msgNoC, velocity=0))
+                        portobject._port_out.send(mido.Message(type="note_on", channel=channel, note=msgNoC, velocity=0))
 
         self.log.debug("Attempting to close midi port(s)")
         for portobject, _ in self._portobjects:


### PR DESCRIPTION
To get the LED-Feedback working on Akai APC20 and APC40 you need to add a second device for the output (LED-Feedback). This is my configuration file:
`
"devices": {
    "1": {
        "devicename": "Akai APC20 0"
    },
	"2": {
        "devicename": "Akai APC20 1"
    }
}
`

But the problem was, the feedback was always sent to channel 0 and you could not change it. So I added the configuration "out_channel" to the config and that it gets used by MIDItoOBS.
If this option is not specified, than it falls back to channel 0 for backward compatibility.
I would suggest to change this to the same channel as "msg_channel" but was not sure about this.